### PR TITLE
Fix for macOS 15

### DIFF
--- a/AutomaticSleepTime.xcodeproj/project.pbxproj
+++ b/AutomaticSleepTime.xcodeproj/project.pbxproj
@@ -257,6 +257,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 			};
@@ -268,6 +269,7 @@
 				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				EXCLUDED_ARCHS = arm64;
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 			};

--- a/AutomaticSleepTime/main.swift
+++ b/AutomaticSleepTime/main.swift
@@ -6,14 +6,10 @@ import Solar
 func authorizeCalendar() {
     switch EKEventStore.authorizationStatus(for: .event) {
     case .notDetermined:
-        EKEventStore().requestAccess(
-            to: .event,
-            completion: { (granted: Bool, error: Error?) in
-                if !granted {
-                    print(error?.localizedDescription ?? "Could not get Calendar access")
-                }
-            }
-        )
+        EKEventStore()
+            .requestFullAccessToEvents(completion: { (granted: Bool, error: Error?) in
+                if !granted { print(error?.localizedDescription ?? "Could not get Calendar access") }
+            })
     case .authorized: break
     case .denied:
         print("User denied Calendar access. Cannot determine location or write events")
@@ -144,7 +140,13 @@ func createSleepEvent(_ eventStore: EKEventStore, inCalendar calendar: EKCalenda
     }
 
     let sleepEvent = EKEvent(eventStore: eventStore)
-    sleepEvent.structuredLocation = locationData.location
+
+    //  We need to deep copy the location to avoid corrupting the original event
+    let newLocation = EKStructuredLocation()
+    newLocation.title = locationData.location.title
+    newLocation.geoLocation = locationData.location.geoLocation
+    sleepEvent.structuredLocation = newLocation
+
     sleepEvent.isAllDay = false
     sleepEvent.startDate = interval.start
     sleepEvent.endDate = interval.end


### PR DESCRIPTION
## Motivation

The script is currently broken on macOS 15. It appears there are two issues:

1. It fails to get access to the Calendar, thus failing to write new events.
2. After fixing that, it shallow copies the location from the location event, corrupting it in the process.

## Changes

- Set the macOS target to 15.
- Use modern API to request Calendar access.
- Deep copy location to the sleep event to prevent corrupting the source event.