### PR TITLE
Run for 10 days for debugging by default

### DIFF
--- a/AutomaticSleepTime.xcodeproj/xcshareddata/xcschemes/AutomaticSleepTime.xcscheme
+++ b/AutomaticSleepTime.xcodeproj/xcshareddata/xcschemes/AutomaticSleepTime.xcscheme
@@ -50,6 +50,12 @@
             ReferencedContainer = "container:AutomaticSleepTime.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "10"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"


### PR DESCRIPTION
## Motivation

For quick debugging, it's useful to see multiple days in advance by default.

## Changes

- Add the default arguments to 10 to generate events 10 days ahead.